### PR TITLE
fix: replacement character in test case id URL

### DIFF
--- a/webapp/src/main/java/io/github/microcks/web/TestController.java
+++ b/webapp/src/main/java/io/github/microcks/web/TestController.java
@@ -134,9 +134,10 @@ public class TestController {
          @PathVariable("testCaseId") String testCaseId
       ) {
       // We may have testCaseId being URLEncoded, with forbidden '/' replaced by '_' so unwrap id.
+      // Switched form _ to ! in replacement as less commonly used in URL parameters, in line with other frameworks e.g. Drupal
       try {
          testCaseId = URLDecoder.decode(testCaseId, StandardCharsets.UTF_8.toString());
-         testCaseId = testCaseId.replace('_', '/');
+         testCaseId = testCaseId.replace('!', '/');
       } catch (UnsupportedEncodingException e) {
          return null;
       }
@@ -150,9 +151,10 @@ public class TestController {
          @PathVariable("testCaseId") String testCaseId
    ) {
       // We may have testCaseId being URLEncoded, with forbidden '/' replaced by '_' so unwrap id.
+      // Switched form _ to ! in replacement as less commonly used in URL parameters, in line with other frameworks e.g. Drupal
       try {
          testCaseId = URLDecoder.decode(testCaseId, StandardCharsets.UTF_8.toString());
-         testCaseId = testCaseId.replace('_', '/');
+         testCaseId = testCaseId.replace('!', '/');
       } catch (UnsupportedEncodingException e) {
          return null;
       }

--- a/webapp/src/main/webapp/src/app/services/tests.service.ts
+++ b/webapp/src/main/webapp/src/app/services/tests.service.ts
@@ -49,8 +49,9 @@ export class TestsService {
 
   public getMessages(test: TestResult, operation: string): Observable<RequestResponsePair> {
     // operation may contain / that are forbidden within encoded URI.
-    // Replace them by "_" and implement same protocole on server-side.
-    operation = operation.replace(/\//g, '_');
+    // Replace them by "!" and implement same protocole on server-side.
+    // Switched from _ to ! in replacement as less commonly used in URL parameters, in line with other frameworks e.g. Drupal
+    operation = operation.replace(/\//g, '!');
     var testCaseId = test.id + '-' + test.testNumber + '-' + encodeURIComponent(operation);
     console.log("[getMessages] called for " + testCaseId);
     return this.http.get<RequestResponsePair>(this.rootUrl + '/tests/' + test.id + '/messages/' + testCaseId);
@@ -58,8 +59,9 @@ export class TestsService {
 
   public getEventMessages(test: TestResult, operation: string): Observable<UnidirectionalEvent> {
     // operation may contain / that are forbidden within encoded URI.
-    // Replace them by "_" and implement same protocole on server-side.
-    operation = operation.replace(/\//g, '_');
+    // Replace them by "!" and implement same protocole on server-side.
+    // Switched from _ to ! in replacement as less commonly used in URL parameters, in line with other frameworks e.g. Drupal
+    operation = operation.replace(/\//g, '!');
     var testCaseId = test.id + '-' + test.testNumber + '-' + encodeURIComponent(operation);
     console.log("[getEventMessages] called for " + testCaseId);
     return this.http.get<UnidirectionalEvent>(this.rootUrl + '/tests/' + test.id + '/events/' + testCaseId);


### PR DESCRIPTION
The "_" replacement used caused problems with APIs using underscore in the parameter names. Switched to safer alternative - "!"